### PR TITLE
Plot size

### DIFF
--- a/Helium.sublime-settings
+++ b/Helium.sublime-settings
@@ -5,10 +5,26 @@
   // #%%
   // # %%
   // # <codecell>
-  "complete": true,  // Whether use Helium' autocomplete powered by Jupyter kernel.
-  "complete_timeout": 0.5, // Timeout to get completion (in seconds).
-  "inline_output": false, // Set to true to show output in current view, like Jupyter
-  "output_code": false, // Set true to show the executed code in the output
+
+  // Whether use Helium' autocomplete powered by Jupyter kernel.
+  "complete": true,
+
+  // Timeout to get completion (in seconds).
+  "complete_timeout": 0.5,
+
+  // Set to true to show output in current view, like Jupyter
+  "inline_output": false,
+
+  // Set true to show the executed code in the output
+  "output_code": false,
+
+  // "image_size" controls the size of the image. It can take one three values:
+  //     "original":         The image is displayed with its original size.
+  //     "resize_to_window": The image is rescaled to match the size of the window.
+  //     "optimal":          The image is either resized or has its original size,
+  //                         whichever is smaller.
+  // The default is "optimal".
+  "image_size": "resize_to_window",
 
   // If you use kernels located in the directory other than default search path
   // (see http://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs),

--- a/Helium.sublime-settings
+++ b/Helium.sublime-settings
@@ -24,7 +24,7 @@
   //     "optimal":          The image is either resized or has its original size,
   //                         whichever is smaller.
   // The default is "optimal".
-  "image_size": "resize_to_window",
+  "image_size": "optimal",
 
   // If you use kernels located in the directory other than default search path
   // (see http://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs),

--- a/lib/kernel.py
+++ b/lib/kernel.py
@@ -437,7 +437,7 @@ class KernelConnection(object):
 
             if dimensions[0] < width:
                 html = IMAGE_PHANTOM.format(
-                    data=data, width=dimensions[0], height=dimensions[0]
+                    data=data, width=dimensions[0], height=dimensions[1]
                 )
             else:
                 scale_factor = width / dimensions[0]

--- a/lib/kernel.py
+++ b/lib/kernel.py
@@ -243,7 +243,7 @@ class KernelConnection(object):
     ):
         """Initialize KernelConnection class.
 
-        paramters
+        parameters
         ---------
         kernel_id str: kernel ID
         parent parent kernel manager
@@ -431,11 +431,16 @@ class KernelConnection(object):
     ):
         if self._show_inline_output:
             id = HELIUM_FIGURE_PHANTOMS + datetime.now().isoformat()
+            img_size = sublime.load_settings("Helium.sublime-settings").get(
+                "image_size", "optimal"
+            )
 
             width = view.viewport_extent()[0] - 2
             dimensions = get_png_dimensions(data)
 
-            if dimensions[0] < width:
+            if img_size == "original" or (
+                img_size == "optimal" and (dimensions[0] < width)
+            ):
                 html = IMAGE_PHANTOM.format(
                     data=data, width=dimensions[0], height=dimensions[1]
                 )
@@ -478,12 +483,21 @@ class KernelConnection(object):
         if "image/png" in mime_data:
             data = mime_data["image/png"].strip()
 
+            img_size = sublime.load_settings("Helium.sublime-settings").get(
+                "image_size", "optimal"
+            )
+
             self._logger.info(self.get_view().viewport_extent())
             width = self.get_view().viewport_extent()[0] - 2
             dimensions = get_png_dimensions(data)
 
-            scale_factor = width / dimensions[0]
-            height = dimensions[1] * scale_factor
+            if img_size == "original" or (
+                img_size == "optimal" and (dimensions[0] < width)
+            ):
+                width, height = dimensions
+            else:
+                scale_factor = width / dimensions[0]
+                height = dimensions[1] * scale_factor
 
             content = (
                 '<body style="background-color:white">'

--- a/lib/kernel.py
+++ b/lib/kernel.py
@@ -159,12 +159,14 @@ class KernelConnection(object):
                     view, region = self._kernel.id2region.get(
                         msg["parent_header"].get("msg_id", None), (None, None)
                     )
-                    
+
                     if msg_type == MSG_TYPE_STATUS:
                         self._kernel._execution_state = content["execution_state"]
                     elif msg_type == MSG_TYPE_EXECUTE_INPUT:
                         self._kernel._write_text_to_view("\n\n")
-                        if sublime.load_settings("Helium.sublime-settings").get("output_code"):
+                        if sublime.load_settings("Helium.sublime-settings").get(
+                            "output_code"
+                        ):
                             self._kernel._output_input_code(
                                 content["code"], content["execution_count"]
                             )
@@ -355,9 +357,7 @@ class KernelConnection(object):
         try:
             lines = """\nError: {ename}, {evalue}.
             \nTraceback:\n{traceback}""".format(
-                ename=ename,
-                evalue=evalue,
-                traceback="\n".join(traceback),
+                ename=ename, evalue=evalue, traceback="\n".join(traceback),
             )
             lines = remove_ansi_escape(lines)
             self._write_text_to_view(lines)
@@ -434,10 +434,16 @@ class KernelConnection(object):
 
             width = view.viewport_extent()[0] - 2
             dimensions = get_png_dimensions(data)
-            scale_factor = width / dimensions[0]
-            height = dimensions[1] * scale_factor
-            
-            html = IMAGE_PHANTOM.format(data=data, width=width, height=height)
+
+            if dimensions[0] < width:
+                html = IMAGE_PHANTOM.format(
+                    data=data, width=dimensions[0], height=dimensions[0]
+                )
+            else:
+                scale_factor = width / dimensions[0]
+                height = dimensions[1] * scale_factor
+
+                html = IMAGE_PHANTOM.format(data=data, width=width, height=height)
 
             view.add_phantom(
                 id,
@@ -534,7 +540,7 @@ class KernelConnection(object):
         msg_id = self.client.execute(code)
         self.id2region[msg_id] = (
             view,
-            sublime.Region(phantom_region.end()-1, phantom_region.end()-1),
+            sublime.Region(phantom_region.end() - 1, phantom_region.end() - 1),
         )
         info_message = "Kernel executed code ```{code}```.".format(code=code)
         self._logger.info(info_message)


### PR DESCRIPTION
Hey there,

second times the charm.

I started using Helium today and realized that images are always scaled to the size of the window. I don't like this and there is also a bug report regarding this.

This pull request scales the figure to the minimum of the window size and the figure size. As such the figure is always displayed as a whole but never larger than the original image.

BR,
C

Fixes #108 