### PR TITLE
Remove duplicate phantoms

### DIFF
--- a/helium.py
+++ b/helium.py
@@ -167,7 +167,7 @@ class HeliumKernelManager(object):
         """Start kernel and return a `Kernel` instance."""
         kernel_id = uuid.uuid4()
         if not cwd:
-            cwd = expanduser('~')
+            cwd = expanduser("~")
 
         if kernelspec_name:
             kernel_manager = KernelManager(kernel_name=kernelspec_name)
@@ -240,7 +240,7 @@ def _start_kernel(window, view, continue_cb=lambda: None, *, logger=HELIUM_LOGGE
     cwd = None
 
     if view:
-        cwd = expanduser('~')
+        cwd = expanduser("~")
     if view and view.file_name():
         cwd = os.path.dirname(view.file_name())
 
@@ -733,7 +733,7 @@ def get_cell(
     )
     separators = view.find_all(cell_delimiter_pattern)
     separators.append(sublime.Region(view.size() + 1, view.size() + 1))
-    r = sublime.Region(region.begin(), region.begin())
+    r = sublime.Region(region.begin() + 1, region.begin() + 1)
     start_point = separators[bisect.bisect(separators, r) - 1].end() + 1
     end_point = separators[bisect.bisect(separators, r)].begin() - 1
     cell_region = sublime.Region(start_point, end_point)

--- a/helium.py
+++ b/helium.py
@@ -732,7 +732,7 @@ def get_cell(
         "cell_delimiter_pattern"
     )
     separators = view.find_all(cell_delimiter_pattern)
-    separators.append(sublime.Region(view.size() + 1, view.size() + 1))
+    separators.append(sublime.Region(view.size() + 2, view.size() + 2))
     r = sublime.Region(region.begin() + 1, region.begin() + 1)
     start_point = separators[bisect.bisect(separators, r) - 1].end() + 1
     end_point = separators[bisect.bisect(separators, r)].begin() - 1

--- a/lib/kernel.py
+++ b/lib/kernel.py
@@ -437,7 +437,7 @@ class KernelConnection(object):
 
             if dimensions[0] < width:
                 html = IMAGE_PHANTOM.format(
-                    data=data, width=dimensions[0], height=dimensions[0]
+                    data=data, width=dimensions[0], height=dimensions[1]
                 )
             else:
                 scale_factor = width / dimensions[0]

--- a/lib/kernel.py
+++ b/lib/kernel.py
@@ -458,16 +458,6 @@ class KernelConnection(object):
 
                 html = IMAGE_PHANTOM.format(data=data, width=width, height=height)
 
-            if dimensions[0] < width:
-                html = IMAGE_PHANTOM.format(
-                    data=data, width=dimensions[0], height=dimensions[1]
-                )
-            else:
-                scale_factor = width / dimensions[0]
-                height = dimensions[1] * scale_factor
-
-                html = IMAGE_PHANTOM.format(data=data, width=width, height=height)
-
             int_id = view.add_phantom(
                 id,
                 region,

--- a/lib/kernel.py
+++ b/lib/kernel.py
@@ -161,8 +161,14 @@ class KernelConnection(object):
                     )
 
                     # clear phantoms if input was executed and should be displayed
-                    if prev_msg_type == "execute_input" and (
-                        msg_type in ("display_data", "error")
+                    output_msgs = (
+                        MSG_TYPE_DISPLAY_DATA,
+                        MSG_TYPE_ERROR,
+                        MSG_TYPE_EXECUTE_RESULT,
+                        MSG_TYPE_STREAM,
+                    )
+                    if prev_msg_type == MSG_TYPE_EXECUTE_INPUT and (
+                        msg_type in output_msgs
                     ):
                         self._kernel._clear_phantoms_in_region(region, view)
 

--- a/lib/kernel.py
+++ b/lib/kernel.py
@@ -159,12 +159,14 @@ class KernelConnection(object):
                     view, region = self._kernel.id2region.get(
                         msg["parent_header"].get("msg_id", None), (None, None)
                     )
-                    
+
                     if msg_type == MSG_TYPE_STATUS:
                         self._kernel._execution_state = content["execution_state"]
                     elif msg_type == MSG_TYPE_EXECUTE_INPUT:
                         self._kernel._write_text_to_view("\n\n")
-                        if sublime.load_settings("Helium.sublime-settings").get("output_code"):
+                        if sublime.load_settings("Helium.sublime-settings").get(
+                            "output_code"
+                        ):
                             self._kernel._output_input_code(
                                 content["code"], content["execution_count"]
                             )
@@ -355,9 +357,7 @@ class KernelConnection(object):
         try:
             lines = """\nError: {ename}, {evalue}.
             \nTraceback:\n{traceback}""".format(
-                ename=ename,
-                evalue=evalue,
-                traceback="\n".join(traceback),
+                ename=ename, evalue=evalue, traceback="\n".join(traceback),
             )
             lines = remove_ansi_escape(lines)
             self._write_text_to_view(lines)
@@ -434,10 +434,16 @@ class KernelConnection(object):
 
             width = view.viewport_extent()[0] - 2
             dimensions = get_png_dimensions(data)
-            scale_factor = width / dimensions[0]
-            height = dimensions[1] * scale_factor
-            
-            html = IMAGE_PHANTOM.format(data=data, width=width, height=height)
+
+            if dimensions[0] < width:
+                html = IMAGE_PHANTOM.format(
+                    data=data, width=dimensions[0], height=dimensions[0]
+                )
+            else:
+                scale_factor = width / dimensions[0]
+                height = dimensions[1] * scale_factor
+
+                html = IMAGE_PHANTOM.format(data=data, width=width, height=height)
 
             view.add_phantom(
                 id,
@@ -534,7 +540,7 @@ class KernelConnection(object):
         msg_id = self.client.execute(code)
         self.id2region[msg_id] = (
             view,
-            sublime.Region(phantom_region.end()-1, phantom_region.end()-1),
+            sublime.Region(phantom_region.end() - 1, phantom_region.end() - 1),
         )
         info_message = "Kernel executed code ```{code}```.".format(code=code)
         self._logger.info(info_message)


### PR DESCRIPTION
This PR fixes the problem of having multiple outputs that stack with each execution of a cell.

With this fix, each cell only shows its own output. If there is already an output present, the existing output is closed and recreated.

What did I do?

  - First of all, I moved the `get_cell` function from `helium.py` to `lib/utils.py`. The reason is that I need the `get_cell` function in `lib/kernel.py`. However, if I import it directly from `helium.py` unnecessary code is executed. 
  - Next, in kernel `lib/kernel.py` I introduced the dict `self.phantoms`. This dictionary tracks the id and the internal integer id of each existing phantom. Each time a phantom is created, both ids are added to the dict.
  - The `def _clear_phantoms_in_region(self, region: sublime.Region, view: sublime.View):` function clears already existing phantoms. First, it calls `get_cell` to get the region of the currently executed cell. Next, it checks using the integer id of each stored phantom if the phantom is in the current cell. If yes, it calls `_erase_phantom`.
  - The `def _erase_phantom(self, pid: str, *, view: sublime.View)` function removes the keys from the `self.phantoms` dict and the phantom itself.
  - Each new message received, we test if the message type is `execute_input`. If yes, `_clear_phantoms_in_region` is called.

Fixes #71
Fixes #124 

This PR doesn't really work if `internal_output` is set to `false`. This case is much more difficult since not only phantoms are used.